### PR TITLE
Add a way to use TELINFO instead of DATE-OBS

### DIFF
--- a/nicpolpy/NICPolReduc.py
+++ b/nicpolpy/NICPolReduc.py
@@ -436,6 +436,7 @@ class NICPolReduc(NICPolReducMixin):
         method="median",
         sigclip_kw=dict(sigma=2, maxiters=5),
         fitting_sections=None,
+        dateobs_by_telinfo=False,
         show_progress=True,
         thumb_kw=dict(ext="pdf", dpi=72, zscale=True, percentiles=[0.01, 99.9, 99.99]),
     ):
@@ -491,6 +492,7 @@ class NICPolReduc(NICPolReducMixin):
                 method=method,
                 sigclip_kw=sigclip_kw,
                 fitting_sections=fitting_sections,
+                dateobs_by_telinfo=dateobs_by_telinfo,
                 dtype="float32",  # hard-coded
                 multi2for_int16=False,  # hard-coded
                 skip_if_exists=self._skipexred[1],
@@ -617,6 +619,7 @@ class NICPolReduc(NICPolReducMixin):
         method="median",
         sigclip_kw=dict(sigma=2, maxiters=5),
         fitting_sections=None,
+        dateobs_by_telinfo=False,
         rm_nonpol=True,
         rm_test=True,
         show_progress=True,
@@ -671,6 +674,7 @@ class NICPolReduc(NICPolReducMixin):
                 dtype="float32",  # hard-coded
                 multi2for_int16=False,  # hard-coded
                 setid=row["SETID"],
+                dateobs_by_telinfo=dateobs_by_telinfo,
                 skip_if_exists=self._skipexred[1],
                 verbose=self.verbose - 2,
             )
@@ -756,6 +760,7 @@ class NICPolReduc(NICPolReducMixin):
         do_mbpm_before_fourier=True,
         cut_wavelength=100,
         vertical_again=True,
+        dateobs_by_telinfo=False,
         bpm_kw=BPM_KW,
         show_progress=True,
     ):
@@ -792,6 +797,7 @@ class NICPolReduc(NICPolReducMixin):
                 cut_wavelength=cut_wavelength,
                 bpm_kw=bpm_kw,
                 vertical_again=vertical_again,
+                dateobs_by_telinfo=dateobs_by_telinfo,
                 skip_if_exists=self._skipexred[2],
                 setid=row["SETID"],
                 verbose=self.verbose - 2,

--- a/nicpolpy/prepare.py
+++ b/nicpolpy/prepare.py
@@ -516,6 +516,7 @@ def _do_16bit_vertical(
         minval=-15000,
         blankval=-32768,
         setid=None,
+        dateobs_by_telinfo=False,
         full=False,
         save=True,
         verbose=1
@@ -563,6 +564,12 @@ def _do_16bit_vertical(
     setid : int, optional.
         The SETID value. Default: 0.
 
+    dateobs_by_telinfo : bool, optional.
+        Whether to use the ``"TELINFO"`` key in the header to update the
+        ``"DATE-OBS"`` key. This should be used when the telescope time sync
+        was in error.
+        Default: `False`.
+
     verbose : int
         Larger number means it becomes more verbose::
             * 0: print nothing
@@ -577,6 +584,7 @@ def _do_16bit_vertical(
         setid=setid,
         process_title=process_title,
         skip_if_exists=skip_if_exists,
+        dateobs_by_telinfo=dateobs_by_telinfo,
         verbose=verbose - 1,
         assert_almost_equal=True
     )
@@ -652,6 +660,7 @@ def _do_vfv(
         cut_wavelength=100,
         bpm_kw=BPM_KW,
         vertical_again=True,
+        dateobs_by_telinfo=False,
         skip_if_exists=True,
         setid=None,
         verbose=True
@@ -735,6 +744,12 @@ def _do_vfv(
         The keyword arguments for the sigma clipping for estimating the
         vertical pattern. To turn sigma-clipping off, set ``maxiters=0``.
 
+    dateobs_by_telinfo : bool, optional.
+        Whether to use the ``"TELINFO"`` key in the header to update the
+        ``"DATE-OBS"`` key. This should be used when the telescope time sync
+        was in error.
+        Default: `False`.
+
     skip_if_exists : bool, optional.
         Whether to skip all process if the file exists in `outdir`.
         Default: `True`.
@@ -765,6 +780,7 @@ def _do_vfv(
         setid=setid,
         process_title=process_title,
         skip_if_exists=skip_if_exists,
+        dateobs_by_telinfo=dateobs_by_telinfo,
         verbose=verbose,
         assert_almost_equal=False  # no need to check
     )
@@ -953,6 +969,7 @@ def proc_16_vertical(
         fitting_sections=None,
         method="median",
         skip_if_exists=True,
+        dateobs_by_telinfo=False,
         rm_nonpol=True,
         rm_test=True,
         verbose=0,
@@ -1019,6 +1036,7 @@ def proc_16_vertical(
             fitting_sections=fitting_sections,
             method=method,
             setid=setid,
+            dateobs_by_telinfo=dateobs_by_telinfo,
             verbose=verbose >= 3
         )
 
@@ -1057,6 +1075,7 @@ def proc_16_vfv(
         cut_wavelength=100,
         vertical_again=True,
         bpm_kw=BPM_KW,
+        dateobs_by_telinfo=False,
         skip_if_exists=True,
         rm_nonpol=True,
         rm_test=True,
@@ -1138,6 +1157,7 @@ def proc_16_vfv(
             vertical_again=vertical_again,
             bpm_kw=bpm_kw,
             skip_if_exists=skip_if_exists,
+            dateobs_by_telinfo=dateobs_by_telinfo,
             setid=setid,
             verbose=verbose >= 3
         )


### PR DESCRIPTION
When telescope sync is in error, DATE-OBS and STR will be erroneous values. In such a case, TELINFO should be used as a rough estimate. (priv. comm. with Jun Takahashi, U. of Hyogo, NHAO, 2025-01-13)